### PR TITLE
Migration to v1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,17 +1,18 @@
 name: docker
-version: 0.1.2
+version: 0.2.0
 
 authors:
   - Jerome Gravel-Niquet <jeromegn@gmail.com>
 
 license: MIT
 
+dependencies:
+  json_mapping:
+    github: crystal-lang/json_mapping.cr
+
 development_dependencies:
   webmock:
     github: manastech/webmock.cr
     branch: master
-  spec2:
-    github: waterlink/spec2.cr
-    branch: master
 
-crystal: 0.27.0
+crystal: ">= 1.0.0"

--- a/spec/docker/client/containers_spec.cr
+++ b/spec/docker/client/containers_spec.cr
@@ -1,13 +1,13 @@
 require "../../spec_helper"
 
 describe Docker::Client::Containers do
-  before { WebMock.reset }
+  before_all { WebMock.reset }
 
-  before { ENV["DOCKER_HOST"] = "tcp://localhost:1337" }
-  after { ENV.delete "DOCKER_HOST" }
+  before_all { ENV["DOCKER_HOST"] = "tcp://localhost:1337" }
+  after_all { ENV.delete "DOCKER_HOST" }
 
   describe ".containers" do
-    before do
+    before_all do
       WebMock
         .stub(:get, "http://localhost:1337/containers/json")
         .with(query: {
@@ -19,9 +19,9 @@ describe Docker::Client::Containers do
         ].to_json)
     end
 
-    subject { Docker.client.containers }
     it "is a Array(Docker::Container)" do
-      expect(subject).to be_a(Array(Docker::Container))
+      containers = Docker.client.containers
+      containers.should be_a(Array(Docker::Container))
     end
   end
 end

--- a/spec/docker/client/info_spec.cr
+++ b/spec/docker/client/info_spec.cr
@@ -1,17 +1,17 @@
 require "../../spec_helper"
 
 describe Docker::Client::Info do
-  before { WebMock.reset }
+  before_all { WebMock.reset }
 
-  before { ENV["DOCKER_HOST"] = "tcp://localhost:1337" }
-  after { ENV.delete "DOCKER_HOST" }
+  before_all { ENV["DOCKER_HOST"] = "tcp://localhost:1337" }
+  after_all { ENV.delete "DOCKER_HOST" }
 
-  describe ".info" do
-    before { WebMock.stub(:get, "http://localhost:1337/info").to_return({"Containers" => 30}.to_json) }
+  describe "#info" do
+    before_all { WebMock.stub(:get, "http://localhost:1337/info").to_return({"Containers" => 30}.to_json) }
 
-    subject { Docker.client.info }
     it "is a Docker::Info" do
-      expect(subject).to be_a(Docker::Info)
+      info = Docker.client.info
+      info.should be_a(Docker::Info)
     end
   end
 

--- a/spec/docker/client_spec.cr
+++ b/spec/docker/client_spec.cr
@@ -5,26 +5,26 @@ describe Docker::Client do
   describe ".new" do
 
     context "defaults" do
-      subject { Docker::Client.new }
       it "uses unix" do 
-        expect(subject.url.to_s).to eq("unix:///var/run/docker.sock")
+        client = Docker::Client.new
+        client.url.to_s.should eq("unix:///var/run/docker.sock")
       end
     end
 
     context "env vars" do
-      before { ENV["DOCKER_HOST"] = "tcp://0.0.0.0:8000" }
-      after { ENV.delete("DOCKER_HOST") }
-      subject { Docker::Client.new }
+      before_all { ENV["DOCKER_HOST"] = "tcp://0.0.0.0:8000" }
+      after_all { ENV.delete("DOCKER_HOST") }
       it "applies environment" do 
-        expect(subject.url.to_s).to eq("tcp://0.0.0.0:8000")
+        client = Docker::Client.new
+        client.url.to_s.should eq("tcp://0.0.0.0:8000")
       end
     end
 
     context "manual setting" do
-      subject { Docker::Client.new }
-      before { subject.url = "tcp://0.0.0.0:8001" }
       it "applies custom setting" do 
-        expect(subject.url.to_s).to eq("tcp://0.0.0.0:8001")
+        client = Docker::Client.new
+        client.url = "tcp://0.0.0.0:8001"
+        client.url.to_s.should eq("tcp://0.0.0.0:8001")
       end
     end
 

--- a/spec/docker/container_spec.cr
+++ b/spec/docker/container_spec.cr
@@ -1,10 +1,9 @@
 require "../spec_helper"
 
 describe Docker::Container do
-  before { WebMock.reset }
-  before { ENV["DOCKER_HOST"] = "tcp://localhost:80" }
-  after { ENV.delete("DOCKER_HOST") }
-  subject { Docker::Container.from_json({"Id" => "test"}.to_json) }
+  before_all { WebMock.reset }
+  before_all { ENV["DOCKER_HOST"] = "tcp://localhost:80" }
+  after_all { ENV.delete("DOCKER_HOST") }
 
   describe "#start" do
 
@@ -29,20 +28,26 @@ describe Docker::Container do
     # end
 
     context "not found" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/start").to_return(status: 404)
       end
       it "raises error" do
-        expect { subject.start }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.start
+        end
       end
     end
 
     context "server error" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/start").to_return(status: 500)
       end
       it "raises error" do
-        expect { subject.start }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.start
+        end
       end
     end
 
@@ -71,20 +76,26 @@ describe Docker::Container do
     # end
 
     context "not found" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/stop?t=5").to_return(status: 404)
       end
       it "raises error" do
-        expect { subject.stop }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.stop
+        end
       end
     end
 
     context "server error" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/stop?t=5").to_return(status: 500)
       end
       it "raises error" do
-        expect { subject.stop }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.stop
+        end
       end
     end
   end
@@ -112,20 +123,26 @@ describe Docker::Container do
     # end
 
     context "not found" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/restart?t=5").to_return(status: 404)
       end
       it "raises error" do
-        expect { subject.restart }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.restart
+        end
       end
     end
 
     context "server error" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/restart?t=5").to_return(status: 500)
       end
       it "raises error" do
-        expect { subject.restart }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.restart
+        end
       end
     end
   end
@@ -153,20 +170,26 @@ describe Docker::Container do
     # end
 
     context "not found" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/kill").to_return(status: 404)
       end
       it "raises error" do
-        expect { subject.kill }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.kill
+        end
       end
     end
 
     context "server error" do
-      before do
+      before_all do
         WebMock.stub(:post, "localhost/containers/test/kill").to_return(status: 500)
       end
       it "raises error" do
-        expect { subject.kill }.to raise_error(Docker::Client::Exception)
+        container = Docker::Container.from_json({"Id" => "test"}.to_json)
+        expect_raises(Docker::Client::Exception) do
+          container.kill
+        end
       end
     end
 

--- a/spec/docker_spec.cr
+++ b/spec/docker_spec.cr
@@ -4,7 +4,7 @@ describe Docker do
 
   describe ".client" do
     it "is a Docker::Client" do
-      expect(Docker.client).to be_a(Docker::Client)
+      Docker.client.should be_a(Docker::Client)
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,4 @@
+require "spec"
 require "webmock"
 require "../src/docker"
 
@@ -5,7 +6,3 @@ ENV.delete("DOCKER_TLS_VERIFY")
 ENV.delete("DOCKER_HOST")
 ENV.delete("DOCKER_URL")
 ENV.delete("DOCKER_CERT_PATH")
-
-require "spec2"
-include Spec2::GlobalDSL
-Spec2.doc

--- a/src/core_ext/http/client.cr
+++ b/src/core_ext/http/client.cr
@@ -8,8 +8,7 @@ class HTTP::Client
   end
 
   def self.unix(path)
-    client = new("localhost")
-    client.socket = UNIXSocket.new(path)
+    client = new UNIXSocket.new(path)
     client
   end
 

--- a/src/docker/container.cr
+++ b/src/docker/container.cr
@@ -1,3 +1,5 @@
+require "json_mapping"
+
 module Docker
   class Container
 

--- a/src/docker/version.cr
+++ b/src/docker/version.cr
@@ -1,3 +1,3 @@
 module Docker
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- Require Crystal `>= 1.0.0`.
- Remove `spec2` shard.
  Not maintained. Replaced with stdlib Spec.
- Require `json_mapping` shard.