### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Docker [![Build Status](https://travis-ci.org/jeromegn/docker.cr.svg?branch=master)](https://travis-ci.org/jeromegn/docker.cr) [![Dependency Status](https://shards.rocks/badge/github/jeromegn/docker.cr/status.svg)](https://shards.rocks/github/jeromegn/docker.cr) [![devDependency Status](https://shards.rocks/badge/github/jeromegn/docker.cr/dev_status.svg)](https://shards.rocks/github/jeromegn/docker.cr)
-
-Docker API client in Crystal.
+# Crystal Docker API client
 
 ## Installation
 


### PR DESCRIPTION
The "fix" is to remove Travis.

An alternative could be to integrate with GitHub Actions.

Closes #8 

https://travis-ci.community/t/apt-get-update-fails-on-builds-with-ubuntu-images/11572/2